### PR TITLE
Correct invalid dunder method name to __post_init__

### DIFF
--- a/py_lab_hal/environment/py_lab_hal_env.py
+++ b/py_lab_hal/environment/py_lab_hal_env.py
@@ -43,7 +43,7 @@ class PyLabHALCom(json_dataclass.DataClassJsonCamelMixIn):
   name: str
   config: cominterface.ConnectConfig
 
-  def __post__init__(self) -> None:
+  def __post_init__(self) -> None:
     self.config.__post_init__()
 
 


### PR DESCRIPTION
I believe what the author meant here is `__post_init__`, not `__post__init__`, as per the Python's documentation: https://docs.python.org/3.9/library/dataclasses.html#post-init-processing.

What it implies is that this method was probably never executed.